### PR TITLE
fix `href` indentation

### DIFF
--- a/snippets.cson
+++ b/snippets.cson
@@ -287,13 +287,13 @@
   'href  (get URL)':
     'prefix': 'href'
     'body':"""
-	   "type": "label",
-	   "text": "trigger href",
-	   "href": {
-		 "url": "...",
-		 "transition": "...",
-		 "view": "..."
-	   }
+      "type": "label",
+      "text": "trigger href",
+      "href": {
+        "url": "...",
+        "transition": "...",
+        "view": "..."
+      }
     """
 
   '$close  (Close a modal (works when the currently view is a modal))':


### PR DESCRIPTION
@j2l Thanks for the repo!
In tested it out I noticed a lot of snippets have a mix of tabs and spaces that mess up the style in my jasonette. It's always better to stick with one or the other. I've fixed up the indentation on the `href` components as an example.